### PR TITLE
Make the path to the tests relative

### DIFF
--- a/qrapi/tests/test_app.py
+++ b/qrapi/tests/test_app.py
@@ -23,7 +23,7 @@ def client(app):
     ]
 )
 def test_upload_pdf(client, authorization, expected_code):
-    file_object = open('/app/tests/files/example_paylogic.pdf', 'rb')
+    file_object = open('tests/files/example_paylogic.pdf', 'rb')
 
     headers = {
         'Authorization': authorization,


### PR DESCRIPTION
Currently, the path to the test files was hardcoded which did not allow for tests to run outside of docker.